### PR TITLE
passes 06_smglom, given latexml #1198

### DIFF
--- a/lib/LaTeXML/Package/omdoc.cls.ltxml
+++ b/lib/LaTeXML/Package/omdoc.cls.ltxml
@@ -6,7 +6,7 @@
 # |  Copyright (c) Michael Kohlhase 2019.                               | #
 # |  This work may be distributed and/or modified under the conditions  | #
 # |  of the LaTeX Project Public License, either version 1.3 of this    | #
-# |  license or later; see http://www.latex-project.org/lppl.txt        | # 
+# |  license or later; see http://www.latex-project.org/lppl.txt        | #
 # |---------------------------------------------------------------------| #
 # | Michael Kohlhase <michael.kohlhase@fau.de>                  #_#     | #
 # | http://github.com/sLaTeX/sTeX                              (o o)    | #
@@ -48,15 +48,15 @@ RegisterNamespace('stex'=>"http://kwarc.info/ns/sTeX");
 RegisterNamespace('ltx'=>"http://dlmf.nist.gov/LaTeXML");
 RelaxNGSchema('omdoc+ltxml',
         '#default'=>"http://omdoc.org/ns",
+        'omdoc'=>"http://omdoc.org/ns",
         'om'=>"http://www.openmath.org/OpenMath",
         'm'=>"http://www.w3.org/1998/Math/MathML",
         'dc'=>"http://purl.org/dc/elements/1.1/",
         'cc'=>"http://creativecommons.org/ns",
-       'stex'=>"http://kwarc.info/ns/sTeX",
+        'stex'=>"http://kwarc.info/ns/sTeX",
        'ltx'=>"http://dlmf.nist.gov/LaTeXML");
 RequirePackage('omdoc');
 RequirePackage('stex');
-
 # =======================================================
 # 2. Document structure                                 #
 # =======================================================

--- a/lib/LaTeXML/Package/stex.sty.ltxml
+++ b/lib/LaTeXML/Package/stex.sty.ltxml
@@ -6,7 +6,7 @@
 # |  Copyright (c) Michael Kohlhase 2019.                               | #
 # |  This work may be distributed and/or modified under the conditions  | #
 # |  of the LaTeX Project Public License, either version 1.3 of this    | #
-# |  license or later; see http://www.latex-project.org/lppl.txt        | # 
+# |  license or later; see http://www.latex-project.org/lppl.txt        | #
 # |---------------------------------------------------------------------| #
 # | Michael Kohlhase <michael.kohlhase@fau.de>                  #_#     | #
 # | http://kwarc.info/kohlhase                                 (o o)    | #
@@ -26,9 +26,6 @@ DeclareOption(undef, sub {PassOptions('statements','sty',ToString(Digest(T_CS('\
   PassOptions('dcm','sty',ToString(Digest(T_CS('\CurrentOption'))));
 });
 ProcessOptions();
-RegisterNamespace("stex","http://kwarc.info/ns/sTeX");
-RegisterNamespace("om","http://www.openmath.org/OpenMath");
-RegisterNamespace("omdoc","http://omdoc.org/ns");
 
 # =======================================================
 # 1. Requirements:                                      #

--- a/lib/LaTeXML/resources/RelaxNG/omdoc+ltxml.model
+++ b/lib/LaTeXML/resources/RelaxNG/omdoc+ltxml.model
@@ -1,4 +1,4 @@
-#default=http://dlmf.nist.gov/LaTeXML
+#default=http://omdoc.org/ns
 omdoc=http://omdoc.org/ns
 xml=http://www.w3.org/XML/1998/namespace
 BackMatter:=(ltx:ERROR,ltx:TOC,ltx:acknowledgements,ltx:appendix,ltx:bibliography,ltx:description,ltx:enumerate,ltx:figure,ltx:float,ltx:glossary,ltx:glossarydefinition,ltx:index,ltx:indexmark,ltx:itemize,ltx:listing,ltx:navigation,ltx:note,ltx:pagination,ltx:para,ltx:proof,ltx:rdf,ltx:resource,ltx:table,ltx:theorem,omdoc:adt,omdoc:alternative,omdoc:assertion,omdoc:axiom,omdoc:chapter,omdoc:code,omdoc:definition,omdoc:example,omdoc:exercise,omdoc:hint,omdoc:ignore,omdoc:mc,omdoc:notation,omdoc:omgroup,omdoc:omtext,omdoc:oref,omdoc:paragraph,omdoc:private,omdoc:proof,omdoc:proofobject,omdoc:ref,omdoc:section,omdoc:solution,omdoc:subparagraph,omdoc:subsection,omdoc:subsubsection,omdoc:symbol,omdoc:tableofcontents,omdoc:theory,omdoc:type,omdoc:verbalization,omdoc:view,xhtml:dl,xhtml:ol,xhtml:ul)

--- a/t/06_smglom.t
+++ b/t/06_smglom.t
@@ -25,7 +25,7 @@ my $tex_input = <<'EOQ';
 \end{modsig}
 \end{document}
 EOQ
-		  
+
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT']);
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
@@ -33,7 +33,7 @@ my $content_query = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+<omdoc xmlns="http://omdoc.org/ns" xmlns:ltx="http://dlmf.nist.gov/LaTeXML" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
   <theory about="#foo" stex:srcref="anonymous_string#textrange(from=3;0,to=6;12)" xml:id="foo">
     <symbol about="#foo.symbol1" name="foo" stex:srcref="anonymous_string#textrange(from=4;0,to=4;26)" xml:id="foo.symbol1"/>
     <notation about="#foo.notation2" cd="foo" name="foo" stex:macro_name="foo" stex:nargs="0" stex:srcref="anonymous_string#textrange(from=4;0,to=4;26)" xml:id="foo.notation2">
@@ -41,7 +41,7 @@ my $content_query = <<'EOQ';
         <om:OMS cd="foo" name="foo"/>
       </prototype>
       <rendering>
-        <text xmlns="http://dlmf.nist.gov/LaTeXML" class="ltx_markedasmath">foo</text>
+        <ltx:text class="ltx_markedasmath">foo</ltx:text>
       </rendering>
     </notation>
   </theory>


### PR DESCRIPTION
It's more of a demonstration than a final fix, as ideally the `.model` file would be generated with omdoc as the default namespace via the trang pipeline.

But once the latexml finalize_rec PR is merged, this PR can revive the smglom test, potentially others.