### PR TITLE
pass 00_cds test

### DIFF
--- a/t/00_cds.t
+++ b/t/00_cds.t
@@ -22,12 +22,12 @@ my $tex_input = <<'EOQ';
 \begin{module}
 \symdef{foo}{\text{foo}}
   \begin{definition}[id=foo.def]
-    A \defi{foo} (we write $\foo$) is a false object offer. 
+    A \defi{foo} (we write $\foo$) is a false object offer.
   \end{definition}
 \end{module}
 \end{document}
 EOQ
-		  
+
 my $config = LaTeXML::Common::Config->new(local=>1, paths=>['./lib/LaTeXML/Package','./lib/LaTeXML/resources/RelaxNG','./lib/LaTeXML/resources/Profiles','./lib/LaTeXML/resources/XSLT']);
 my $converter = LaTeXML->get_converter($config);
 my $response = $converter->convert("literal:$tex_input");
@@ -35,12 +35,12 @@ my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
-  <theory about="#omdoc1.theory1" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1">
-    <metadata about="#omdoc1.theory1.metadata1" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1">
-      <dc:creator about="#omdoc1.theory1.metadata1.creator1" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.creator1"/>
-      <dc:contributor about="#omdoc1.theory1.metadata1.contributor2" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.contributor2"/>
-      <meta about="#omdoc1.theory1.metadata1.meta3" property="smglom:state" stex:srcref="anonymous_string#textrange(from=3;1,to=8;12)" xml:id="omdoc1.theory1.metadata1.meta3"/>
+<omdoc xmlns="http://omdoc.org/ns" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ltx="http://dlmf.nist.gov/LaTeXML" xmlns:om="http://www.openmath.org/OpenMath" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+  <theory about="#omdoc1.theory1" stex:srcref="anonymous_string#textrange(from=3;0,to=8;12)" xml:id="omdoc1.theory1">
+    <metadata about="#omdoc1.theory1.metadata1" stex:srcref="anonymous_string#textrange(from=3;0,to=8;12)" xml:id="omdoc1.theory1.metadata1">
+      <dc:creator about="#omdoc1.theory1.metadata1.creator1" stex:srcref="anonymous_string#textrange(from=3;0,to=8;12)" xml:id="omdoc1.theory1.metadata1.creator1"/>
+      <dc:contributor about="#omdoc1.theory1.metadata1.contributor2" stex:srcref="anonymous_string#textrange(from=3;0,to=8;12)" xml:id="omdoc1.theory1.metadata1.contributor2"/>
+      <meta about="#omdoc1.theory1.metadata1.meta3" property="smglom:state" stex:srcref="anonymous_string#textrange(from=3;0,to=8;12)" xml:id="omdoc1.theory1.metadata1.meta3"/>
     </metadata>
     <symbol about="#omdoc1.theory1.symbol2" name="foo" stex:srcref="anonymous_string#textrange(from=4;0,to=4;24)" xml:id="omdoc1.theory1.symbol2"/>
     <notation about="#omdoc1.theory1.notation3" cd="theory1" name="foo" stex:macro_name="foo" stex:nargs="0" stex:srcref="anonymous_string#textrange(from=4;0,to=4;24)" xml:id="omdoc1.theory1.notation3">
@@ -48,17 +48,17 @@ my $target_xml = <<'EOQ';
         <om:OMS cd="theory1" name="foo"/>
       </prototype>
       <rendering>
-        <text xmlns="http://dlmf.nist.gov/LaTeXML" class="ltx_markedasmath">foo</text>
+        <ltx:text class="ltx_markedasmath">foo</ltx:text>
       </rendering>
     </notation>
     <symbol about="#foo.def.sym" name="foo" stex:srcref="anonymous_string#textrange(from=5;0,to=7;18)" xml:id="foo.def.sym"/>
     <definition about="#foo.def" for="foo" stex:srcref="anonymous_string#textrange(from=5;0,to=7;18)" xml:id="foo.def">
-      <CMP about="#foo.def.CMP1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;33)" xml:id="foo.def.CMP1">
-        <p xmlns="http://dlmf.nist.gov/LaTeXML" about="#foo.def.CMP1.p1" stex:srcref="anonymous_string#textrange(from=5;54,to=6;33)" xml:id="foo.def.CMP1.p1">A <definiendum cd="theory1" name="foo">foo</definiendum> (we write <Math about="#foo.def.CMP1.p1.m1" font="italic" mode="inline" stex:srcref="anonymous_string#textrange(from=5;27,to=6;33)" tex="\@foo@construct[default]" text="foo" xml:id="foo.def.CMP1.p1.m1">
-            <XMath>
-              <XMTok meaning="foo" name="foo" omcd="theory1"/>
-            </XMath>
-          </Math>) is a false object offer.</p>
+      <CMP about="#foo.def.CMP1" stex:srcref="anonymous_string#textrange(from=6;5,to=6;33)" xml:id="foo.def.CMP1">
+        <ltx:p about="#foo.def.CMP1.p1" stex:srcref="anonymous_string#textrange(from=6;5,to=6;33)" xml:id="foo.def.CMP1.p1">A <definiendum cd="theory1" name="foo">foo</definiendum> (we write <ltx:Math about="#foo.def.CMP1.p1.m1" font="italic" mode="inline" stex:srcref="anonymous_string#textrange(from=6;32,to=6;33)" tex="\@foo@construct[default]" text="foo" xml:id="foo.def.CMP1.p1.m1">
+            <ltx:XMath>
+              <ltx:XMTok meaning="foo" name="foo" omcd="theory1"/>
+            </ltx:XMath>
+          </ltx:Math>) is a false object offer.</ltx:p>
       </CMP>
     </definition>
   </theory>
@@ -81,4 +81,3 @@ while (@got_lines) {
   my $expected_line = shift @expected_lines;
   is($got_line, $expected_line,"Compared line $index of XML output.");
 }
-

--- a/t/01_cmath.t
+++ b/t/01_cmath.t
@@ -37,100 +37,100 @@ my $target_xml = <<'EOQ';
 <?xml version="1.0" encoding="UTF-8"?>
 <?latexml class="smglom"?>
 <?latexml RelaxNGSchema="omdoc+ltxml"?>
-<omdoc xmlns="http://omdoc.org/ns" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
+<omdoc xmlns="http://omdoc.org/ns" xmlns:ltx="http://dlmf.nist.gov/LaTeXML" xmlns:stex="http://kwarc.info/ns/sTeX" about="#omdoc1" stex:srcref="anonymous_string#textrange(from=2;0,to=0;0)" xml:id="omdoc1">
   <theory about="#mathapp" stex:srcref="anonymous_string#textrange(from=3;0,to=10;12)" xml:id="mathapp">
-    <omtext about="#mathapp.omtext1" stex:srcref="anonymous_string#textrange(from=4;1,to=9;12)" xml:id="mathapp.omtext1">
-      <CMP about="#mathapp.omtext1.CMP1" stex:srcref="anonymous_string#textrange(from=4;25,to=8;16)" xml:id="mathapp.omtext1.CMP1">
-        <equation xmlns="http://dlmf.nist.gov/LaTeXML" font="italic" xml:id="S0.Ex1">
-          <Math about="#S0.Ex1.m1" mode="display" stex:srcref="anonymous_string#textrange(from=4;25,to=8;16)" tex="\nappa{f}{a_{1},a_{2},a_{3}}\@napp@seq[]{f}{a_{1}}{a_{n}}\@napp@seq[]{f}{a_{1}%&#10;}{a_{n}}\@napp@seq[]{f}{a^{1}}{a^{n}}" text="f@(list@(a _ 1, a _ 2, a _ 3)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a ^ 1, sequencefromto, a ^ n))" xml:id="S0.Ex1.m1">
-            <XMath>
-              <XMApp>
-                <XMTok meaning="times" role="MULOP">⁢</XMTok>
-                <XMApp>
-                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
-                  <XMDual>
-                    <XMApp>
-                      <XMTok meaning="list"/>
-                      <XMRef idref="S0.Ex1.m1.1"/>
-                      <XMRef idref="S0.Ex1.m1.2"/>
-                      <XMRef idref="S0.Ex1.m1.3"/>
-                    </XMApp>
-                    <XMWrap>
-                      <XMApp xml:id="S0.Ex1.m1.1">
-                        <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                        <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                        <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</XMTok>
-                      </XMApp>
-                      <XMTok font="upright" mode="math" role="PUNCT">,</XMTok>
-                      <XMApp xml:id="S0.Ex1.m1.2">
-                        <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                        <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                        <XMTok font="upright" fontsize="70%" meaning="2" mode="math" role="NUMBER" rule="Subscript">2</XMTok>
-                      </XMApp>
-                      <XMTok font="upright" mode="math" role="PUNCT">,</XMTok>
-                      <XMApp xml:id="S0.Ex1.m1.3">
-                        <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                        <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                        <XMTok font="upright" fontsize="70%" meaning="3" mode="math" role="NUMBER" rule="Subscript">3</XMTok>
-                      </XMApp>
-                    </XMWrap>
-                  </XMDual>
-                </XMApp>
-                <XMApp>
-                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
-                  <XMApp>
-                    <XMTok meaning="sequence"/>
-                    <XMApp>
-                      <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                      <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</XMTok>
-                    </XMApp>
-                    <XMTok meaning="sequencefromto"/>
-                    <XMApp>
-                      <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                      <XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Subscript">n</XMTok>
-                    </XMApp>
-                  </XMApp>
-                </XMApp>
-                <XMApp>
-                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
-                  <XMApp>
-                    <XMTok meaning="sequence"/>
-                    <XMApp>
-                      <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                      <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</XMTok>
-                    </XMApp>
-                    <XMTok meaning="sequencefromto"/>
-                    <XMApp>
-                      <XMTok role="SUBSCRIPTOP" scriptpos="post4"/>
-                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                      <XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Subscript">n</XMTok>
-                    </XMApp>
-                  </XMApp>
-                </XMApp>
-                <XMApp>
-                  <XMTok mode="math" role="UNKNOWN">f</XMTok>
-                  <XMApp>
-                    <XMTok meaning="sequence"/>
-                    <XMApp>
-                      <XMTok role="SUPERSCRIPTOP" scriptpos="post4"/>
-                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                      <XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Superscript">1</XMTok>
-                    </XMApp>
-                    <XMTok meaning="sequencefromto"/>
-                    <XMApp>
-                      <XMTok role="SUPERSCRIPTOP" scriptpos="post4"/>
-                      <XMTok mode="math" role="UNKNOWN">a</XMTok>
-                      <XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Superscript">n</XMTok>
-                    </XMApp>
-                  </XMApp>
-                </XMApp>
-              </XMApp>
-            </XMath>
-          </Math>
-        </equation>
+    <omtext about="#mathapp.omtext1" stex:srcref="anonymous_string#textrange(from=4;0,to=9;12)" xml:id="mathapp.omtext1">
+      <CMP about="#mathapp.omtext1.CMP1" stex:srcref="anonymous_string#textrange(from=5;2,to=8;16)" xml:id="mathapp.omtext1.CMP1">
+        <ltx:equation font="italic" xml:id="S0.Ex1">
+          <ltx:Math about="#S0.Ex1.m1" mode="display" stex:srcref="anonymous_string#textrange(from=5;2,to=8;16)" tex="\nappa{f}{a_{1},a_{2},a_{3}}\@napp@seq[]{f}{a_{1}}{a_{n}}\@napp@seq[]{f}{a_{1}%&#10;}{a_{n}}\@napp@seq[]{f}{a^{1}}{a^{n}}" text="f@(list@(a _ 1, a _ 2, a _ 3)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a _ 1, sequencefromto, a _ n)) * f@(sequence@(a ^ 1, sequencefromto, a ^ n))" xml:id="S0.Ex1.m1">
+            <ltx:XMath>
+              <ltx:XMApp>
+                <ltx:XMTok meaning="times" role="MULOP">⁢</ltx:XMTok>
+                <ltx:XMApp>
+                  <ltx:XMTok mode="math" role="UNKNOWN">f</ltx:XMTok>
+                  <ltx:XMDual>
+                    <ltx:XMApp>
+                      <ltx:XMTok meaning="list"/>
+                      <ltx:XMRef idref="S0.Ex1.m1.1"/>
+                      <ltx:XMRef idref="S0.Ex1.m1.2"/>
+                      <ltx:XMRef idref="S0.Ex1.m1.3"/>
+                    </ltx:XMApp>
+                    <ltx:XMWrap>
+                      <ltx:XMApp xml:id="S0.Ex1.m1.1">
+                        <ltx:XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
+                        <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                        <ltx:XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</ltx:XMTok>
+                      </ltx:XMApp>
+                      <ltx:XMTok font="upright" mode="math" role="PUNCT">,</ltx:XMTok>
+                      <ltx:XMApp xml:id="S0.Ex1.m1.2">
+                        <ltx:XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
+                        <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                        <ltx:XMTok font="upright" fontsize="70%" meaning="2" mode="math" role="NUMBER" rule="Subscript">2</ltx:XMTok>
+                      </ltx:XMApp>
+                      <ltx:XMTok font="upright" mode="math" role="PUNCT">,</ltx:XMTok>
+                      <ltx:XMApp xml:id="S0.Ex1.m1.3">
+                        <ltx:XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
+                        <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                        <ltx:XMTok font="upright" fontsize="70%" meaning="3" mode="math" role="NUMBER" rule="Subscript">3</ltx:XMTok>
+                      </ltx:XMApp>
+                    </ltx:XMWrap>
+                  </ltx:XMDual>
+                </ltx:XMApp>
+                <ltx:XMApp>
+                  <ltx:XMTok mode="math" role="UNKNOWN">f</ltx:XMTok>
+                  <ltx:XMApp>
+                    <ltx:XMTok meaning="sequence"/>
+                    <ltx:XMApp>
+                      <ltx:XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
+                      <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                      <ltx:XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</ltx:XMTok>
+                    </ltx:XMApp>
+                    <ltx:XMTok meaning="sequencefromto"/>
+                    <ltx:XMApp>
+                      <ltx:XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
+                      <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                      <ltx:XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Subscript">n</ltx:XMTok>
+                    </ltx:XMApp>
+                  </ltx:XMApp>
+                </ltx:XMApp>
+                <ltx:XMApp>
+                  <ltx:XMTok mode="math" role="UNKNOWN">f</ltx:XMTok>
+                  <ltx:XMApp>
+                    <ltx:XMTok meaning="sequence"/>
+                    <ltx:XMApp>
+                      <ltx:XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
+                      <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                      <ltx:XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Subscript">1</ltx:XMTok>
+                    </ltx:XMApp>
+                    <ltx:XMTok meaning="sequencefromto"/>
+                    <ltx:XMApp>
+                      <ltx:XMTok role="SUBSCRIPTOP" scriptpos="post1"/>
+                      <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                      <ltx:XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Subscript">n</ltx:XMTok>
+                    </ltx:XMApp>
+                  </ltx:XMApp>
+                </ltx:XMApp>
+                <ltx:XMApp>
+                  <ltx:XMTok mode="math" role="UNKNOWN">f</ltx:XMTok>
+                  <ltx:XMApp>
+                    <ltx:XMTok meaning="sequence"/>
+                    <ltx:XMApp>
+                      <ltx:XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
+                      <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                      <ltx:XMTok font="upright" fontsize="70%" meaning="1" mode="math" role="NUMBER" rule="Superscript">1</ltx:XMTok>
+                    </ltx:XMApp>
+                    <ltx:XMTok meaning="sequencefromto"/>
+                    <ltx:XMApp>
+                      <ltx:XMTok role="SUPERSCRIPTOP" scriptpos="post1"/>
+                      <ltx:XMTok mode="math" role="UNKNOWN">a</ltx:XMTok>
+                      <ltx:XMTok fontsize="70%" mode="math" role="UNKNOWN" rule="Superscript">n</ltx:XMTok>
+                    </ltx:XMApp>
+                  </ltx:XMApp>
+                </ltx:XMApp>
+              </ltx:XMApp>
+            </ltx:XMath>
+          </ltx:Math>
+        </ltx:equation>
       </CMP>
     </omtext>
   </theory>


### PR DESCRIPTION
- the changes in the locators come unilaterally from the latexml core changes. They ought to be proofed carefully eventually, and ideally some additional upgrades may be needed to get them "flawless". They continue to be "good enough" (as in they span at least parts of the correct range, and do not overflow it), so I updated the attribute values in the test.

- The other change comes in the (I would argue "correct") way the `ltx` namespace is now serialized, via `ltx:` name prefixes to the latexml attributes. It is more direct to read, and arguably a less confusing programming model - the omdoc namespace remains the default namespace for the entirety of an stex-generated document, all foreign namespaces are using their [qualified names](https://en.wikipedia.org/wiki/QName). 

The core aspects of the test itself were unharmed.